### PR TITLE
fix: correct -ignore help text

### DIFF
--- a/pkg/core/command.go
+++ b/pkg/core/command.go
@@ -245,7 +245,7 @@ func (cmd *Command) Main(args []string) int {
 
 	flags := flag.NewFlagSet(args[0], flag.ContinueOnError)
 	flags.SetOutput(cmd.Stderr)
-	flags.Var(&ignorePats, "ignore", "Regular expression matching to error messages you want to ignore. This flag is repeatable")
+	flags.Var(&ignorePats, "ignore", "Regular expression matching rule names you want to ignore. This flag is repeatable")
 	flags.Var(&enabledRules, "enable-rule",
 		"Enable an opt-in rule by name. Repeatable. "+
 			"Currently available opt-in rules: missing-timeout-minutes")

--- a/pkg/core/command_test.go
+++ b/pkg/core/command_test.go
@@ -1,0 +1,24 @@
+package core
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCommandHelpDescribesIgnorePatternAsRuleName(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := &Command{
+		Stdin:  strings.NewReader(""),
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+
+	if got := cmd.Main([]string{"sisakulint", "-help"}); got != ExitStatusSuccessNoProblem {
+		t.Fatalf("Main(-help) exit code = %d, want %d", got, ExitStatusSuccessNoProblem)
+	}
+	if !strings.Contains(stderr.String(), "Regular expression matching rule names you want to ignore.") {
+		t.Fatalf("-ignore help text = %q, want it to describe rule-name matching", stderr.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Correct the `-ignore` flag description to state that patterns match rule names.
- Add a regression test for the CLI help output.

Fixes #591

## Test Plan
- [x] `GOTOOLCHAIN=go1.25.13 go test -race ./...`
- [x] `GOTOOLCHAIN=go1.25.13 go build ./cmd/sisakulint`
- [x] `GOTOOLCHAIN=go1.25.13 go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * `-ignore` オプションのヘルプ説明を更新し、ルール名にマッチする正規表現であることを明確化しました。

* **テスト**
  * ヘルプ表示に新しい説明文が含まれることを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->